### PR TITLE
Removing duplicate "AtRestEncryptionEnabled: true"

### DIFF
--- a/ecs-nextcloud.yml
+++ b/ecs-nextcloud.yml
@@ -796,7 +796,6 @@ Resources:
       ReplicationGroupDescription: 'redis cache for nextcloud'
       AutomaticFailoverEnabled: false
       NumCacheClusters: 1
-      AtRestEncryptionEnabled: true
       MultiAZEnabled: false
       CacheNodeType: !Ref RedisTshirtSize
       CacheParameterGroupName: !Ref RedisParameterGroup


### PR DESCRIPTION
Lines 799 and 817 are dupes which was preventing cloud formation designer from rendering the template. Fixed and verified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
